### PR TITLE
Updated `paragon.onKillCreatureOrPlayer`

### DIFF
--- a/lua_scripts/D3_Paragon/paragon-server.lua
+++ b/lua_scripts/D3_Paragon/paragon-server.lua
@@ -324,6 +324,7 @@ function paragon.onKillCreatureOrPlayer(event, player, victim)
             paragon.setExp(player, victim, 1)
         end
     end
+    return false
 end
 RegisterPlayerEvent(6, paragon.onKillCreatureOrPlayer)
 RegisterPlayerEvent(7, paragon.onKillCreatureOrPlayer)


### PR DESCRIPTION
* Explicitly return false to ensure other handlers continue to process